### PR TITLE
Exclude repository-only files from distribution archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -31,3 +31,16 @@
 *.gif binary
 *.ico binary
 *.mo binary
+
+# Exclude repository-only files from distribution archives (git archive / Composer dist).
+# These files are needed for development but not at runtime, keeping the published package lean.
+# https://git-scm.com/docs/gitattributes#_export_ignore
+/.editorconfig      export-ignore
+/.gitattributes     export-ignore
+/.github            export-ignore
+/.gitignore         export-ignore
+/.idea              export-ignore
+/composer.lock      export-ignore
+/phpcs.xml.dist     export-ignore
+/phpunit.xml.dist   export-ignore
+/tests              export-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 - Improved overall documentation
+- Exclude repository-only files from archives to reduce Composer distribution package size [#21](https://github.com/orca-services/cakephp-swagger-ui/issues/21)
 
 ### Fixed
 


### PR DESCRIPTION
Add support for Git’s .gitattributes export-ignore directive to control which files are included when the package is distributed via Composer.

This allows us to exclude repository-only files (e.g. tests, CI configs, docs, tooling) from distribution archives and keep the package leaner.

Closes #21 